### PR TITLE
Ajout d’une méthode qui manquante dans Bano et Fantoir

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Reprend les fonctionnalités de addrfantoir.py et ajoute le rattachement des n°
 
 Requiert le script adresses_buildings.sql et un accès en RW à une base PostGIS.
 
-Le fichier pg_connexion.py est à renommer en pg_connexion.py et à adapter en modifiant les parties entre <>.
+Le fichier pg_connexion.py.txt est à renommer en pg_connexion.py et à adapter en modifiant les parties entre <>.
 
 ***************
 addrfantoir.py : recherche du code FANTOIR des voies pour enrichissement d'un fichier d'adresses déjà regroupées en relations associatedStreet.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ addr_fantoir_building.py
 
 Reprend les fonctionnalités de addrfantoir.py et ajoute le rattachement des n° d'adresse aux bâtiments sous forme de tag porté par le way building.
 
-Requiert le script adresses_buildings.sql et un accès en RW à une base PostGIS.
+Requiert le script adresses_buildings.sql, accès en RO à une base OSM Monde (schema osm2pgsql) et un accès en RW à une base PostGIS.
+
 
 Le fichier pg_connexion.py.txt est à renommer en pg_connexion.py et à adapter en modifiant les parties entre <>.
 

--- a/pg_connexion.py.txt
+++ b/pg_connexion.py.txt
@@ -3,3 +3,7 @@ import psycopg2
 def get_pgc():
 	pgc = psycopg2.connect("dbname='<nom de la base PostGIS>' user='<user>' host='<hote>' password='<mot de passe>'")
 	return pgc
+
+def get_pgc_layers():
+	pgc = psycopg2.connect("dbname='<nom de la base OSM>' user='<user>' host='<hote>' password='<mot de passe>'")
+	return pgc


### PR DESCRIPTION
Je me permets d’ajouter la méthode manquante dans le template de pg_connexion.py :)
